### PR TITLE
Fix possible values and default value displayed on args taking none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### next
+- fix some unwanted possible values and default values with clap 4.4.14+ - Fix #2
 
 <a name="1.1.1"></a>
 ### v1.1.1 - 2024-01-29

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,5 +1,5 @@
 use {
-    clap::Command,
+    clap::{ArgAction, Command},
     std::collections::HashMap,
     termimad::{
         minimad::{OwningTemplateExpander, TextTemplate},
@@ -177,11 +177,16 @@ impl<'t> Printer<'t> {
                     "possible_values",
                     format!(" Possible values: [{}]", possible_values.join(", ")),
                 );
-                if let Some(default) = arg.get_default_values().first() {
-                    expander.sub("option-lines").set_md(
-                        "default",
-                        format!(" Default: `{}`", default.to_string_lossy()),
-                    );
+            }
+            if let Some(default) = arg.get_default_values().first() {
+                match arg.get_action() {
+                    ArgAction::Set | ArgAction::Append => {
+                        expander.sub("option-lines").set_md(
+                            "default",
+                            format!(" Default: `{}`", default.to_string_lossy()),
+                        );
+                    }
+                    _ => {}
                 }
             }
         }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -62,7 +62,8 @@ pub struct Printer<'t> {
 }
 
 impl<'t> Printer<'t> {
-    pub fn new(cmd: Command) -> Self {
+    pub fn new(mut cmd: Command) -> Self {
+        cmd.build();
         let expander = Self::make_expander(&cmd);
         let mut templates = HashMap::new();
         templates.insert("title", TEMPLATE_TITLE);
@@ -176,12 +177,12 @@ impl<'t> Printer<'t> {
                     "possible_values",
                     format!(" Possible values: [{}]", possible_values.join(", ")),
                 );
-            }
-            if let Some(default) = arg.get_default_values().first() {
-                expander.sub("option-lines").set_md(
-                    "default",
-                    format!(" Default: `{}`", default.to_string_lossy()),
-                );
+                if let Some(default) = arg.get_default_values().first() {
+                    expander.sub("option-lines").set_md(
+                        "default",
+                        format!(" Default: `{}`", default.to_string_lossy()),
+                    );
+                }
             }
         }
         let mut args = String::new();


### PR DESCRIPTION
Most especially on --help and --version.
This is due to a breaking change in clap 4.1.14.

Fix #2 